### PR TITLE
Implemented command to invoke clsqh

### DIFF
--- a/demo/benchflow.py
+++ b/demo/benchflow.py
@@ -1,32 +1,51 @@
 import click
 import requests
+import subprocess
 
-expManager = "localhost:9980"
+expManagerAddress = "http://localhost:8080"
 
 @click.group()
-def faban():
-	pass
+def expManager():
+	pass	
 
-@faban.command()
+@expManager.command()
 @click.argument("benchmark", type=click.Path(exists=True))
 def deploy(benchmark):
+	"""Deploys a BenchFlow benchmark"""
 	filename = click.format_filename(benchmark)
 	file = { 'file': open(filename, 'rb') }
-	r = requests.post(expManager + "/faban/deploy", files=file)
+	r = requests.post(expManagerAddress + "/faban/deploy", files=file)
 	click.echo(r.json())
 
-@faban.command()
+@expManager.command()
 @click.argument("benchmarkshortname")
 #@click.argument("configfile", type=click.Path(exists=True))
 def run(benchmarkshortname):
-	r = requests.post(expManager + "/faban/run/" + benchmarkshortname)
+	"""Runs a BenchFlow benchmark"""
+	r = requests.post(expManagerAddress + "/faban/run/" + benchmarkshortname)
 	click.echo(r.json())
 
-@faban.command()
+@expManager.command()
 @click.argument("runid")
 def status(runid):
-	r = requests.get(expManager + "/faban/status/" + runid)
+	"""Returns the status of a benchmark run"""
+	r = requests.get(expManagerAddress + "/faban/status/" + runid)
 	click.echo(r.json())		
 
+@click.group()
+def cassandra(args):
+	pass
+
+@cassandra.command()
+@click.argument("host")
+@click.argument("port")
+def clsqh(host, port):
+	"""Starts clsqh"""
+	cmd = list(("clsqh", host, port))
+	click.echo(cmd)
+	subprocess.run(cmd)
+
+benchflowClient = click.CommandCollection(sources=[expManager, cassandra])
+
 if __name__ == '__main__':
-	faban()
+	benchflowClient()


### PR DESCRIPTION
- Implemented command to invoke `clsqh`
- Refactored commands in two different groups, `cassandra` related
commands and `experiments-manager` related commands.
- Added description for each command (helpful when the script is
invoked without any command to see the available ones)

Please not that this version of the client requires python 3.5, because it uses the `subprocess.run` function.